### PR TITLE
Standardize license headers in Python files

### DIFF
--- a/clip/__init__.py
+++ b/clip/__init__.py
@@ -1,1 +1,3 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 from .clip import *

--- a/clip/clip.py
+++ b/clip/clip.py
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 import hashlib
 import os
 import urllib

--- a/clip/model.py
+++ b/clip/model.py
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 from collections import OrderedDict
 from typing import Tuple, Union
 

--- a/clip/simple_tokenizer.py
+++ b/clip/simple_tokenizer.py
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 import gzip
 import html
 import os

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 import re
 import string
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 import os
 
 import pkg_resources

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,10 +1,11 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-import clip
 import numpy as np
 import pytest
 import torch
 from PIL import Image
+
+import clip
 
 
 @pytest.mark.parametrize("model_name", clip.available_models())

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,9 +1,10 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+import clip
 import numpy as np
 import pytest
 import torch
 from PIL import Image
-
-import clip
 
 
 @pytest.mark.parametrize("model_name", clip.available_models())


### PR DESCRIPTION
This PR updates all Python file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all Python files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
This PR adds Ultralytics' licensing information to multiple files across the codebase.

### 📊 Key Changes  
- Added the Ultralytics AGPL-3.0 license header to the following files:
  - `clip/__init__.py`
  - `clip/clip.py`
  - `clip/model.py`
  - `clip/simple_tokenizer.py`
  - `hubconf.py`
  - `setup.py`
  - `tests/test_consistency.py`

### 🎯 Purpose & Impact  
- 🛡️ **Purpose**: Ensure proper attribution and compliance with the AGPL-3.0 license within the repository.
- 🌍 **Impact**: This change clarifies the licensing terms for users and contributors, ensuring legal use and distribution while reinforcing transparency and open-source principles. No functionality or performance changes are introduced.