### PR TITLE
Add CI retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,8 @@ jobs:
         run: uv pip install --system -e . torch==${{ matrix.pytorch-version }} torchvision pytest --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: Run tests
-        run: uv run pytest
+        uses: ultralytics/actions/retry@main
+        with:
+          retries: 2
+          retry_delay_seconds: 10
+          run: uv run pytest


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary  
CI tests now automatically retry on failure to reduce flaky test noise 🔁✅

### 📊 Key Changes  
- Replaced the direct `uv run pytest` step with the [`ultralytics/actions/retry`](https://github.com/ultralytics/actions) wrapper 🧰  
- Configured CI to retry tests up to **2 times** with a **10-second delay** between attempts ⏱️  
- No changes to the codebase itself—this update is limited to the GitHub Actions workflow (`.github/workflows/ci.yml`) 🛠️

### 🎯 Purpose & Impact  
- Improves CI reliability by handling intermittent/flaky failures (e.g., transient runner or dependency issues) 🌩️➡️🌤️  
- Reduces unnecessary red CI runs and manual re-runs, saving maintainer time and speeding up iteration 🚀  
- Helps contributors get clearer signals: failures are more likely to represent real issues rather than one-off hiccups 🧪🔍