### PR TITLE
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
         run: uv pip install --system -e . torch==${{ matrix.pytorch-version }} torchvision pytest --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/ci.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions CI workflow to use `astral-sh/setup-uv@v8` instead of `@v7`, keeping the repository’s automation tooling current.

### 📊 Key Changes
- Updated the CI workflow file `.github/workflows/ci.yml`.
- Changed the GitHub Action for UV setup from `astral-sh/setup-uv@v7` to `astral-sh/setup-uv@v8`.
- No changes were made to model code, training logic, or user-facing features.

### 🎯 Purpose & Impact
- 🚀 Keeps the CI pipeline aligned with the latest supported version of the UV setup action.
- 🛠️ May improve workflow reliability, compatibility, and maintainability in GitHub Actions.
- ✅ Helps reduce the risk of issues caused by older CI dependencies.
- 👥 Minimal direct impact for end users, but beneficial for developers by keeping automated testing and installation workflows up to date.