### PR TITLE
Bump astral-sh/setup-uv to v8 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
         run: uv pip install --system -e . torch==${{ matrix.pytorch-version }} torchvision pytest --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
Bump astral-sh/setup-uv to v8 in /.github/workflows

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub CI workflow to use a newer version of `astral-sh/setup-uv`, improving dependency setup in automated testing.

### 📊 Key Changes
- Updated the CI workflow in `.github/workflows/ci.yml`
- Changed the GitHub Action from `astral-sh/setup-uv@v7` to `astral-sh/setup-uv@v8`
- Kept the rest of the dependency installation and test process unchanged

### 🎯 Purpose & Impact
- 🚀 Helps keep the repository’s CI pipeline up to date with the latest `setup-uv` action improvements
- 🛠️ May improve reliability, compatibility, or performance when installing dependencies during tests
- ✅ Low-risk maintenance change since it only affects CI tooling, not the CLIP library code itself
- 👩‍💻 Users of the package should see no direct API or feature changes, but developers may benefit from a smoother testing workflow