### PR TITLE
Declare packaging runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ requires-python = ">=3.7"
 # Core dependencies needed for CLIP functionality
 dependencies = [
     "ftfy",      # Text preprocessing library for fixing Unicode errors
+    "packaging",  # Version parsing used for PyTorch compatibility checks
     "regex",     # Enhanced regular expression library
     "tqdm",      # Progress bar library for tracking long-running operations
     "torch",     # PyTorch deep learning framework


### PR DESCRIPTION
## Summary
- add `packaging` to `pyproject.toml` runtime dependencies
- completes integration of upstream OpenAI CLIP packaging compatibility change from openai/CLIP#449 / commit `dcba3cb`

## Upstream scan
Compared `ultralytics/CLIP` against `openai/CLIP` on `main`:
- `dcba3cb` replaces `pkg_resources.packaging` with `packaging.version`; the fork already has the code change, but was missing the declared runtime dependency. This PR adds it.
- `ded190a` updates upstream `setup.py`; not applicable because the fork has moved packaging metadata to `pyproject.toml` and no longer has `setup.py`.
- `d05afc4` pins upstream `.github/workflows/test.yml` actions; not applicable directly because the fork replaced that workflow with its own `ci.yml`/Ultralytics Actions workflows.

## Validation
- Parsed `pyproject.toml` and asserted `packaging` is declared
- `python -m compileall -q clip tests`
- `python - <<'PY'` import smoke for `clip.available_models()`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
➕ This PR adds the `packaging` dependency to `ultralytics/CLIP` so the project can reliably handle PyTorch version compatibility checks.

### 📊 Key Changes
- Added `packaging` to `pyproject.toml` dependencies.
- Documented its purpose inline as being used for version parsing in PyTorch compatibility checks.
- No model, training, or inference logic was changed—this is a dependency and environment-management update only.

### 🎯 Purpose & Impact
- Improves dependency reliability by ensuring version comparisons use a proper, standard library 🛠️
- Helps prevent runtime issues related to PyTorch version detection or compatibility handling ✅
- Makes installations more robust across different environments and setups 📦
- Low-risk change for users, with the main effect being better stability behind the scenes rather than visible feature changes 🙂