### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         pytorch-version: [2.5.0, 2.8.0]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step in CI from `actions/checkout@v6` to `actions/checkout@v7` to keep the automation workflow current.

### 📊 Key Changes
- ⬆️ Updated `.github/workflows/ci.yml`
- 🔧 Changed the CI workflow dependency from `actions/checkout@v6` to `actions/checkout@v7`
- ✅ No model, training, or inference code was modified

### 🎯 Purpose & Impact
- 🛡️ Keeps the repository’s CI pipeline aligned with the latest GitHub Actions version
- 🚀 May improve workflow reliability, compatibility, and access to upstream fixes
- 👥 Low-risk maintenance update with little to no direct impact on end users, but helps developers by keeping automated testing healthy and up to date