### PR TITLE
Declare packaging dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "tqdm",      # Progress bar library for tracking long-running operations
     "torch",     # PyTorch deep learning framework
     "torchvision",  # Computer vision library for PyTorch
+    "packaging",  # version parsing in clip.py (not pulled transitively by torch)
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`clip/clip.py` imports `from packaging import version` (torch version checks at lines 27, 252) but `packaging` was not declared in `dependencies` and isn't pulled transitively by torch. So `pip install git+https://github.com/ultralytics/CLIP.git` followed by `import clip` fails in minimal environments (verified on a clean Python 3.12 venv: `ModuleNotFoundError: No module named 'packaging'`). Declaring it makes the package install self-sufficiently. Verified the fix pulls packaging and imports cleanly.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds the `packaging` dependency to ensure reliable version parsing used in `clip.py` 📦

### 📊 Key Changes
- Added `packaging` to the main project dependencies in `pyproject.toml`
- Documented that this package is required for version parsing in `clip.py`
- Clarified that `packaging` should not be assumed to come indirectly from `torch`

### 🎯 Purpose & Impact
- Ensures installs are more reliable by explicitly including a dependency the project already uses ✅
- Prevents runtime errors in environments where `packaging` is not installed automatically
- Improves dependency clarity and reproducibility for developers, users, and downstream integrations 🔧
- A small but important maintenance fix that makes setup more robust across different systems 🚀