### PR TITLE
Remove dead legacy-torch version checks (drop packaging dependency)

### DIFF
--- a/clip/clip.py
+++ b/clip/clip.py
@@ -216,7 +216,7 @@ def load(name: str, device: str | torch.device = None, jit: bool = False, downlo
 
 def tokenize(
     texts: str | list[str], context_length: int = 77, truncate: bool = False
-) -> torch.IntTensor | torch.LongTensor:
+) -> torch.IntTensor:
     """Returns the tokenized representation of given input string(s).
 
     Parameters
@@ -232,8 +232,7 @@ def tokenize(
 
     Returns
     -------
-    A two-dimensional tensor containing the resulting tokens, shape = [number of input strings, context_length]. We
-    return LongTensor when torch version is <1.8.0, since older index_select requires indices to be long.
+    A two-dimensional tensor containing the resulting tokens, shape = [number of input strings, context_length].
     """
     if isinstance(texts, str):
         texts = [texts]

--- a/clip/clip.py
+++ b/clip/clip.py
@@ -8,7 +8,6 @@ import urllib
 import warnings
 
 import torch
-from packaging import version
 from PIL import Image
 from torchvision.transforms import CenterCrop, Compose, Normalize, Resize, ToTensor
 from tqdm import tqdm
@@ -22,10 +21,6 @@ try:
     BICUBIC = InterpolationMode.BICUBIC
 except ImportError:
     BICUBIC = Image.BICUBIC
-
-
-if version.parse(torch.__version__) < version.parse("1.7.1"):
-    warnings.warn("PyTorch version 1.7.1 or higher is recommended")
 
 
 __all__ = ["available_models", "load", "tokenize"]
@@ -246,11 +241,7 @@ def tokenize(
     sot_token = _tokenizer.encoder["<|startoftext|>"]
     eot_token = _tokenizer.encoder["<|endoftext|>"]
     all_tokens = [[sot_token, *_tokenizer.encode(text), eot_token] for text in texts]
-    result = torch.zeros(
-        len(all_tokens),
-        context_length,
-        dtype=torch.long if version.parse(torch.__version__) < version.parse("1.8.0") else torch.int,
-    )
+    result = torch.zeros(len(all_tokens), context_length, dtype=torch.int)
 
     for i, tokens in enumerate(all_tokens):
         if len(tokens) > context_length:

--- a/clip/clip.py
+++ b/clip/clip.py
@@ -214,9 +214,7 @@ def load(name: str, device: str | torch.device = None, jit: bool = False, downlo
     return model, _transform(model.input_resolution.item())
 
 
-def tokenize(
-    texts: str | list[str], context_length: int = 77, truncate: bool = False
-) -> torch.IntTensor:
+def tokenize(texts: str | list[str], context_length: int = 77, truncate: bool = False) -> torch.IntTensor:
     """Returns the tokenized representation of given input string(s).
 
     Parameters


### PR DESCRIPTION
`clip/clip.py` used `packaging.version.parse` in exactly two places, both dead for the supported torch range (Ultralytics requires `torch>=1.8.0`):
- a `torch<1.7.1` `warnings.warn` that never fires, and
- a `torch<1.8.0` tokenize dtype branch that is always `torch.int` on modern torch.

Deleting both (and the `from packaging import version` import) removes the `packaging` dependency entirely — slimmer and self-sufficient, no new dep needed. Verified on a bare Python 3.12 venv: packaging is not installed, and `import clip` + `clip.tokenize()` work (dtype torch.int32, shape (1, 77)). `warnings` stays (used elsewhere).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR simplifies `clip.py` by removing old PyTorch version checks and standardizing text tokenization to always return `torch.int` tensors.

### 📊 Key Changes
- Removed the dependency on `packaging.version` since PyTorch version parsing is no longer needed.
- Deleted the warning that recommended PyTorch `1.7.1` or higher.
- Simplified the `tokenize()` type annotation so it now always returns `torch.IntTensor`.
- Updated `tokenize()` implementation to always create token tensors with `dtype=torch.int`.
- Cleaned up the `tokenize()` docstring by removing notes about older PyTorch compatibility behavior.

### 🎯 Purpose & Impact
- ✅ Reduces legacy compatibility code, making the file easier to maintain and understand.
- 🚀 Assumes a more modern PyTorch baseline, which helps streamline behavior across supported environments.
- 🔄 Makes tokenization output more predictable by always using the same tensor type.
- ⚠️ Users on very old PyTorch versions may lose compatibility, but most current users should see no functional change.
- 🧼 Overall, this is a small modernization and cleanup PR with minimal user-facing impact.