### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
 
       - name: Install dependencies
         run: uv pip install --system -e . torch==${{ matrix.pytorch-version }} torchvision pytest --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
## Summary
- replace all 1 Astral uv setup steps with the shared retried owner
- preserve existing Python and environment behavior

Reused: ultralytics/actions/setup-uv@main is the single latest-uv installer owner.

Deleted: 1 direct astral-sh/setup-uv dependencies and obsolete Astral-only cache inputs where present.

## Validation
- zero executable astral-sh/setup-uv occurrences
- all setup callers are exactly ultralytics/actions/setup-uv@main
- actionlint on changed workflows; any reported warnings are pre-existing on unchanged lines
- git diff --check
- shared owner passed Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔧 Updates CI to use Ultralytics’ shared `setup-uv` action for consistent Python environment setup.

### 📊 Key Changes

- Replaces `astral-sh/setup-uv@v7` with `ultralytics/actions/setup-uv@main` in the GitHub Actions workflow.
- Keeps the existing dependency installation and test configuration unchanged.

### 🎯 Purpose & Impact

- ✅ Standardizes CI tooling across Ultralytics repositories.
- 🚀 Centralizes maintenance of the `uv` setup process.
- 🧪 Preserves the current test matrix and should not change local package behavior or user-facing functionality.