### PR TITLE
Remove trailing slashes and update redirected Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -80,6 +80,6 @@ body:
       label: Are you willing to submit a PR?
       description: >
         (Optional) We encourage you to submit a [Pull Request](https://github.com/ultralytics/CLIP/pulls) to help improve Ultralytics CLIP, especially if you know how to fix the issue.
-        See the Ultralytics [Contributing Guide](https://docs.ultralytics.com/help/contributing/) to get started.
+        See the Ultralytics [Contributing Guide](https://docs.ultralytics.com/help/contributing) to get started.
       options:
         - label: Yes I'd like to help by submitting a PR!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,11 +6,11 @@ contact_links:
     url: https://github.com/ultralytics/CLIP#readme
     about: Usage notes, model card, and notebooks
   - name: 💬 Forum
-    url: https://community.ultralytics.com/
+    url: https://community.ultralytics.com
     about: Ask the Ultralytics community for workflow help
   - name: 🎧 Discord
     url: https://ultralytics.com/discord
     about: Chat with the Ultralytics team and other builders
   - name: ⌨️ Reddit
-    url: https://reddit.com/r/ultralytics
+    url: https://www.reddit.com/r/ultralytics/
     about: Discuss Ultralytics projects on Reddit

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -46,6 +46,6 @@ body:
       label: Are you willing to submit a PR?
       description: >
         (Optional) We encourage you to submit a [Pull Request](https://github.com/ultralytics/CLIP/pulls) to help improve Ultralytics CLIP.
-        See the Ultralytics [Contributing Guide](https://docs.ultralytics.com/help/contributing/) to get started.
+        See the Ultralytics [Contributing Guide](https://docs.ultralytics.com/help/contributing) to get started.
       options:
         - label: Yes I'd like to help by submitting a PR!

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # CLIP
 
-CLIP (Contrastive Language-Image Pre-Training) is a [neural network](https://www.ultralytics.com/glossary/neural-network-nn) trained on a diverse set of (image, text) pairs sourced from the internet. Developed by OpenAI, it can be instructed using [natural language](https://www.ultralytics.com/glossary/natural-language-processing-nlp) to predict the most relevant text snippet for a given image, without needing task-specific training data. This capability mirrors the [zero-shot learning](https://www.ultralytics.com/glossary/zero-shot-learning) performance seen in models like [GPT-2](https://openai.com/index/better-language-models/) and [GPT-3](https://www.ultralytics.com/glossary/gpt-3). Notably, CLIP matches the performance of the original [ResNet50](https://arxiv.org/abs/1512.03385) on [ImageNet](https://docs.ultralytics.com/datasets/classify/imagenet/) [classification tasks](https://docs.ultralytics.com/tasks/classify/) "zero-shot," meaning it achieves this without using any of the 1.28 million labeled examples from the ImageNet training set, thereby overcoming significant challenges in traditional [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv). For more details, see the [OpenAI blog post](https://openai.com/index/clip/), the original [research paper](https://arxiv.org/abs/2103.00020), the [model card](model-card.md), and try our [interactive Colab notebook](https://colab.research.google.com/github/ultralytics/CLIP/blob/main/notebooks/Interacting_with_CLIP.ipynb).
+CLIP (Contrastive Language-Image Pre-Training) is a [neural network](https://www.ultralytics.com/glossary/neural-network-nn) trained on a diverse set of (image, text) pairs sourced from the internet. Developed by OpenAI, it can be instructed using [natural language](https://www.ultralytics.com/glossary/natural-language-processing-nlp) to predict the most relevant text snippet for a given image, without needing task-specific training data. This capability mirrors the [zero-shot learning](https://www.ultralytics.com/glossary/zero-shot-learning) performance seen in models like [GPT-2](https://openai.com/index/better-language-models/) and [GPT-3](https://www.ultralytics.com/glossary/gpt-3). Notably, CLIP matches the performance of the original [ResNet50](https://arxiv.org/abs/1512.03385) on [ImageNet](https://docs.ultralytics.com/datasets/classify/imagenet) [classification tasks](https://docs.ultralytics.com/tasks/classify) "zero-shot," meaning it achieves this without using any of the 1.28 million labeled examples from the ImageNet training set, thereby overcoming significant challenges in traditional [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv). For more details, see the [OpenAI blog post](https://openai.com/index/clip/), the original [research paper](https://arxiv.org/abs/2103.00020), the [model card](model-card.md), and try our [interactive Colab notebook](https://colab.research.google.com/github/ultralytics/CLIP/blob/main/notebooks/Interacting_with_CLIP.ipynb).
 
 [![Ultralytics Actions](https://github.com/ultralytics/CLIP/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/CLIP/actions/workflows/format.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
-[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
-[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
+[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
+[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
 
 ## 🖼️ Approach
 
@@ -274,7 +274,7 @@ test_features, test_labels = get_features(test_dataset, model, device)
 
 # Train a logistic regression classifier
 # Note: The hyperparameter C should ideally be tuned using a validation set.
-# See https://docs.ultralytics.com/guides/hyperparameter-tuning/ for tuning strategies.
+# See https://docs.ultralytics.com/guides/hyperparameter-tuning for tuning strategies.
 print("Training logistic regression classifier...")
 classifier = LogisticRegression(random_state=0, C=0.316, max_iter=1000, verbose=0)  # Reduced verbosity
 classifier.fit(train_features, train_labels)
@@ -288,20 +288,20 @@ print(f"Linear probe accuracy = {accuracy:.3f}%")
 # Expected output might be around 70-80% accuracy for ViT-B/32 on CIFAR-100
 ```
 
-**Note:** The regularization strength `C` is a crucial [hyperparameter](https://www.ultralytics.com/glossary/hyperparameter-tuning). Its optimal value should be found through techniques like [cross-validation](https://www.ultralytics.com/glossary/cross-validation) or using a dedicated validation split, rather than using a fixed value as shown here for simplicity. Refer to our [Hyperparameter Tuning Guide](https://docs.ultralytics.com/guides/hyperparameter-tuning/) for more details.
+**Note:** The regularization strength `C` is a crucial [hyperparameter](https://www.ultralytics.com/glossary/hyperparameter-tuning). Its optimal value should be found through techniques like [cross-validation](https://www.ultralytics.com/glossary/cross-validation) or using a dedicated validation split, rather than using a fixed value as shown here for simplicity. Refer to our [Hyperparameter Tuning Guide](https://docs.ultralytics.com/guides/hyperparameter-tuning) for more details.
 
 ## 🔗 See Also
 
 - **[OpenCLIP](https://github.com/mlfoundations/open_clip):** An open-source implementation offering various pre-trained CLIP models, including larger ones like ViT-G/14, trained on the LAION dataset.
 - **[Hugging Face Transformers `CLIPModel`](https://huggingface.co/docs/transformers/model_doc/clip):** Provides an implementation of CLIP integrated within the popular [Hugging Face](https://www.ultralytics.com/glossary/hugging-face) ecosystem, facilitating easier use with other Transformers models and tools.
-- **[Ultralytics YOLO Models](https://docs.ultralytics.com/models/):** Explore state-of-the-art [object detection](https://www.ultralytics.com/glossary/object-detection) models like [YOLO11](https://docs.ultralytics.com/models/yolo11/) which can be used alongside or as alternatives to CLIP for various vision tasks.
+- **[Ultralytics YOLO Models](https://docs.ultralytics.com/models):** Explore state-of-the-art [object detection](https://www.ultralytics.com/glossary/object-detection) models like [YOLO11](https://docs.ultralytics.com/models/yolo11) which can be used alongside or as alternatives to CLIP for various vision tasks.
 - **[Multi-Modal Learning Glossary](https://www.ultralytics.com/glossary/multi-modal-learning):** Understand the broader context of models that process information from multiple modalities like text and images.
 
 ## 💡 Contribute
 
 Contributions are the lifeblood of the [open-source](https://www.ultralytics.com/blog/tips-to-start-contributing-to-ultralytics-open-source-projects) community, and we greatly appreciate your input! Whether it's bug fixes, feature suggestions, or documentation improvements, every contribution helps.
 
-Please see our [Contributing Guide](https://docs.ultralytics.com/help/contributing/) for detailed instructions on how to get involved. We also encourage you to fill out our [Survey](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey) to share your feedback. Thank you 🙏 to everyone who contributes!
+Please see our [Contributing Guide](https://docs.ultralytics.com/help/contributing) for detailed instructions on how to get involved. We also encourage you to fill out our [Survey](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey) to share your feedback. Thank you 🙏 to everyone who contributes!
 
 [![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 

--- a/model-card.md
+++ b/model-card.md
@@ -1,4 +1,4 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # Model Card: CLIP
 
@@ -6,8 +6,8 @@ Inspired by [Model Cards for Model Reporting (Mitchell et al.)](https://arxiv.or
 
 [![Ultralytics Actions](https://github.com/ultralytics/CLIP/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/CLIP/actions/workflows/format.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
-[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
-[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
+[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
+[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
 
 ## 📋 Model Details
 
@@ -31,7 +31,7 @@ Please see the paper linked below for further details about their specification.
 
 ### Documents
 
-- [Blog Post](https://openai.com/blog/clip/)
+- [Blog Post](https://openai.com/index/clip/)
 - [CLIP Paper](https://arxiv.org/abs/2103.00020)
 
 ## 🎯 Model Use
@@ -122,7 +122,7 @@ Please use [this Google Form](https://docs.google.com/forms/d/e/1FAIpQLSfRGWV17m
 
 Contributions are the lifeblood of the [open-source](https://www.ultralytics.com/blog/tips-to-start-contributing-to-ultralytics-open-source-projects) community, and we greatly appreciate your input! Whether it's bug fixes, feature suggestions, or documentation improvements, every contribution helps.
 
-Please see our [Contributing Guide](https://docs.ultralytics.com/help/contributing/) for detailed instructions on how to get involved. We also encourage you to fill out our [Survey](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey) to share your feedback. Thank you 🙏 to everyone who contributes!
+Please see our [Contributing Guide](https://docs.ultralytics.com/help/contributing) for detailed instructions on how to get involved. We also encourage you to fill out our [Survey](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey) to share your feedback. Thank you 🙏 to everyone who contributes!
 
 [![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 


### PR DESCRIPTION
Canonicalizes Ultralytics links in this fork: drops the terminating path slash from every `ultralytics.com` / `*.ultralytics.com` URL and refreshes the two links that were still pointing at permanently moved destinations.

## Trailing slashes (15 URLs, 5 files)

Applied with a purpose-built regex fixer that was unit-tested on 31 positive/negative cases before running (subdomains, protocol-relative, bare-host, `/page/#frag`, `/page/?query`, sentence-final `com/.` and `com/!`, markdown/HTML/backtick delimiters; negatives: `github.com/ultralytics/...`, emails, `notultralytics.com`, URL-encoded `https%3A%2F%2F` badge params, `{placeholder}` templates and f-strings, ellipsis `/...`).

- `README.md`, `model-card.md` — logo links, forum badge targets, docs deep links, and the code-comment link in the linear-probe example.
- `.github/ISSUE_TEMPLATE/{bug-report,feature-request}.yml` — contributing guide links.
- `.github/ISSUE_TEMPLATE/config.yml` — forum contact link.

Only path-terminating slashes were touched. The shields.io forum badge keeps its percent-encoded `server=https%3A%2F%2Fcommunity.ultralytics.com` parameter byte-identical, and the `https://ultralytics.com/license` header line on every file is untouched. All 8 distinct rewritten targets were verified to return HTTP 200 with zero redirect hops.

## Redirect refresh (2 accepted)

- `https://openai.com/blog/clip/` -> `https://openai.com/index/clip/` in `model-card.md` (OpenAI moved `/blog/` to `/index/`; the README already used the new form).
- `https://reddit.com/r/ultralytics` -> `https://www.reddit.com/r/ultralytics/` in `README.md`, `model-card.md`, and `.github/ISSUE_TEMPLATE/config.yml` — canonical host redirect, and it matches the form used across the main `ultralytics/ultralytics` repo.

### Rejected redirects

- `https://ultralytics.com/discord` — vanity shortlink, must stay a redirect rather than be frozen to an expiring invite.
- `https://ultralytics.com/license` -> `https://www.ultralytics.com/license` — license header string owned by Ultralytics Actions; rewriting it would desync the tool from its own output.
- `docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates` (`.github/dependabot.yml`) -> destination inserts an `/en/` locale segment; the locale-neutral link is the durable one.
- `https://fsf.org/` -> `https://www.fsf.org/` — inside the verbatim AGPL-3.0 `LICENSE` text, which is a legal record and stays byte-identical.
- `https://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz` -> `cave.cs.toronto.edu/...` — appears only in stored notebook stdout, a historical execution record, not a link.

### Dead link flagged (not changed)

`model-card.md` line 59 links YFCC100M to `http://projects.dfki.uni-kl.de/yfcc100m/`, which now returns 404 over both http and https. It is upstream OpenAI model-card text, so it is left as-is here and flagged for a human to pick a replacement rather than guessing a substitute page.

## Validation

Full diff reviewed line by line: it is URL text only, no code or prose changes. `prettier@3.8.5 --print-width 120 --check` passes on the changed Markdown and YAML, and all three issue-template YAMLs parse. No Python file was modified, so `pytest`/CI behavior is unaffected by the diff.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Canonicalized Ultralytics URLs and updated two redirected external links across the README, model card, and GitHub issue templates.

### 📊 Key Changes

- Removed trailing slashes from Ultralytics links, including documentation, forum, logo, badge, and contributing-guide URLs.
- Updated Reddit links to `https://www.reddit.com/r/ultralytics/` in the README, model card, and issue-template configuration.
- Replaced the moved OpenAI CLIP blog URL with `https://openai.com/index/clip/` in `model-card.md`.
- Preserved the encoded forum badge parameter, license header URLs, Discord vanity link, and other explicitly excluded links.

### 🎯 Purpose & Impact

- Documentation and issue-template links now use canonical URL forms and avoid the specified redirects.
- No code or runtime behavior changed; the diff only updates URL text in Markdown and YAML files.